### PR TITLE
feat(web): Add a custom error handler to gokit

### DIFF
--- a/web/error/handler.go
+++ b/web/error/handler.go
@@ -1,0 +1,57 @@
+package error
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+)
+
+func Handler(logger zerolog.Logger) echo.HTTPErrorHandler {
+	ll := logger.With().Str("middleware", "errorHandler").Logger()
+	return func(err error, c echo.Context) {
+		if c.Response().Committed {
+			return
+		}
+
+		ll.Err(err).
+			Str("requestID", c.Request().Header.Get(echo.HeaderXRequestID)).
+			Msg("request returned an error")
+
+		he, ok := err.(*echo.HTTPError)
+		if ok {
+			if he.Internal != nil {
+				if herr, ok := he.Internal.(*echo.HTTPError); ok {
+					he = herr
+				}
+			}
+		} else {
+			he = &echo.HTTPError{
+				Code:    http.StatusInternalServerError,
+				Message: http.StatusText(http.StatusInternalServerError),
+			}
+		}
+
+		// Issue #1426
+		code := he.Code
+		message := he.Message
+		if m, ok := he.Message.(string); ok {
+			if c.Echo().Debug {
+				message = echo.Map{"code": code, "message": m, "error": err.Error()}
+			} else {
+				message = echo.Map{"code": code, "message": m}
+			}
+		}
+
+		// Send response
+		if c.Request().Method == http.MethodHead { // Issue #608
+			err = c.NoContent(he.Code)
+		} else {
+			err = c.JSON(code, message)
+		}
+		if err != nil {
+
+			c.Logger().Error(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #15 

Custom error handler that's a literal copy of echo's current built in error handler with two changes. The changes will be pointed out in code comments.