### PR TITLE
chore(web): Use request ID helper function, remove unneeded code

### DIFF
--- a/web/error/handler.go
+++ b/web/error/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
+
 	kitHttp "github.com/suborbital/go-kit/web/http"
 )
 

--- a/web/error/handler.go
+++ b/web/error/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog"
+	kitHttp "github.com/suborbital/go-kit/web/http"
 )
 
 func Handler(logger zerolog.Logger) echo.HTTPErrorHandler {
@@ -15,7 +16,7 @@ func Handler(logger zerolog.Logger) echo.HTTPErrorHandler {
 		}
 
 		ll.Err(err).
-			Str("requestID", c.Request().Header.Get(echo.HeaderXRequestID)).
+			Str("requestID", kitHttp.RID(c)).
 			Msg("request returned an error")
 
 		he, ok := err.(*echo.HTTPError)

--- a/web/mid/logger.go
+++ b/web/mid/logger.go
@@ -4,6 +4,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog"
+	"github.com/suborbital/go-kit/web/http"
 )
 
 // Logger middleware configures echo's built in middleware.RequestLoggerWithConfig middleware. The passed in
@@ -43,7 +44,7 @@ func Logger(l zerolog.Logger, skipPaths []string) echo.MiddlewareFunc {
 			l.Info().
 				Str("path", c.Path()).
 				Str("URI", c.Request().RequestURI).
-				Str("requestID", c.Response().Header().Get(echo.HeaderXRequestID)).
+				Str("requestID", http.RID(c)).
 				Str("method", c.Request().Method).
 				Msg("request started")
 		},

--- a/web/mid/logger.go
+++ b/web/mid/logger.go
@@ -4,6 +4,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/rs/zerolog"
+
 	"github.com/suborbital/go-kit/web/http"
 )
 

--- a/web/mid/requestid.go
+++ b/web/mid/requestid.go
@@ -1,14 +1,10 @@
 package mid
 
 import (
-	"context"
-
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
-
-const RequestIDKey = "requestID"
 
 // UUIDRequestID configures echo's built in request id middleware so that the ID generated is an UUIDv4, and the
 // generated request ID is added to the following three parts of the request:
@@ -21,12 +17,6 @@ func UUIDRequestID() echo.MiddlewareFunc {
 	return middleware.RequestIDWithConfig(middleware.RequestIDConfig{
 		Generator: func() string {
 			return uuid.New().String()
-		},
-		RequestIDHandler: func(c echo.Context, s string) {
-			c.Set(RequestIDKey, s)
-			ctx := c.Request().Context()
-			ctx = context.WithValue(ctx, RequestIDKey, s)
-			c.SetRequest(c.Request().WithContext(ctx))
 		},
 	})
 }


### PR DESCRIPTION
Closes #20 

Makes use of the `http.RID(c)` function, and removes unneeded extra "let's store request ID into all these other places as well!" code.