### PR TITLE
feat(zerolog): Add default log level helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/labstack/echo/v4 v4.10.2
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.0
+	github.com/sethvargo/go-envconfig v0.9.0
 	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/otel v1.13.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.29.0 h1:Zes4hju04hjbvkVkOhdl2HpZa+0PmVwigmo8XoORE5w=
 github.com/rs/zerolog v1.29.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
+github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
+github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/loglevel/loglevel.go
+++ b/loglevel/loglevel.go
@@ -37,3 +37,26 @@ func SetLoggerLevel(l zerolog.Logger) zerolog.Logger {
 
 	return l.Level(lvl)
 }
+
+func FromEnv(prefix string) zerolog.Level {
+	return FromLookuper(prefix, envconfig.OsLookuper())
+}
+
+func FromLookuper(prefix string, l envconfig.Lookuper) zerolog.Level {
+	l = envconfig.PrefixLookuper(prefix, l)
+	c := getC(l)
+
+	if c.Debug {
+		return zerolog.DebugLevel
+	}
+
+	return zerolog.InfoLevel
+}
+
+func getC(l envconfig.Lookuper) Config {
+	var c Config
+	if err := envconfig.ProcessWith(context.Background(), &c, l); err != nil {
+		// do nothing
+	}
+	return c
+}

--- a/loglevel/loglevel.go
+++ b/loglevel/loglevel.go
@@ -1,0 +1,39 @@
+package loglevel
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+type Config struct {
+	Debug bool `env:"DEBUG,default=false"`
+}
+
+func SetGlobal() {
+	var c Config
+	if err := envconfig.Process(context.Background(), &c); err != nil {
+		// do nothing, leave it at the default "not debug, therefore info+"
+	}
+
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	if c.Debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+}
+
+func SetLoggerLevel(l zerolog.Logger) zerolog.Logger {
+	lvl := zerolog.InfoLevel
+	var c Config
+	if err := envconfig.Process(context.Background(), &c); err != nil {
+		// do nothing, leave it at the default "not debug, therefore info+"
+	}
+
+	if c.Debug {
+		lvl = zerolog.DebugLevel
+	}
+
+	return l.Level(lvl)
+}


### PR DESCRIPTION
Closes #25 

I've tried a number of different approaches, but I think every single approach is just too much work and too much indirection for them to exist in a separate module.

It does not cut down on the amount of code, it makes the initialization of services more complex, the developers need to keep in mind and remember the environment variable names and how they work, how the kit is configured. All in all I don't think it's of sufficient benefit that it should be abstracted away.

## Problem definition
Per the conversation on threads, the wish is to have a unified way of setting the logger to a specific level based on an environment variable.

As context:
* each service already has their own configuration structs and configuration resolution that they need for startup
* each service already has the loggers being instantiated in the services themselves mostly because the loggers need to have metadata, or key-value pairs attached to them

An example to the latter as a minimum setup
```go
func main() {
    zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
    l := zerolog.New(os.Stderr).With().
        Timestamp().
        Str("service", "builder").
        Str("version", "v1.1.1").
        Str("sha", "acab1312").
        Logger()

    // rest of the service
```

This code only runs once every time a service starts up. Of this the parts that aren't service specific are
* it needs a timestamp
* it should be of unix format
* it should go to os.Stderr (maybe?)

As an experiment I extracted all that into a `Baseline` function. To use that here's what the service needs to do:

```go
import "github.com/suborbital/go-kit/loglevel"

func main() {
    l := loglevel.Baseline("BUILDER_")

    l = l.With().
        Str("service", "builder").
        Str("version", "v1.1.1").
        Str("sha", "acab1312").
        Logger()

    // rest of the service
}
```
It does not cut down on lines of code, it hides implementation which makes figuring out what's happening harder than necessary to do. On the other hand it adds another dependency that we need, and it does not remove dependencies that we already have.

The PR also includes a bunch of other experiments, but in all cases the settings achieved in zerolog can be done in fewer lines with greater accuracy and precision directly than hiding it behind a kit function / module.

Personally I advocate for dealing with setting log levels in the services directly by using their already existing config structs and dedicating 3 lines in the setup code in all 4 places this is currently needed.

Marked the PR as draft because I do not have the intention of merging it in with current context. I am open to be persuaded if the problem definition warrants abstraction. I don't think the current one does.
